### PR TITLE
Fix extension install by making lsp an executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 grammars
 *.wasm
+.DS_Store

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@ impl VHDLExtension {
                     fs::remove_dir_all(&entry.path()).ok();
                 }
             }
+
+            zed::make_file_executable(&binary_path)?;
         }
 
         self.cached_binary_path = Some(binary_path.clone());


### PR DESCRIPTION
## Issue

When installing this extension through `zed: install dev extension`, the extension binary is not made an executable, causing this error `No such file or directory (os error 2)` when attempting to run the VHDL LSP. 

## Fix

This PR should fix it by calling `zed::make_file_executable(&binary_path)`